### PR TITLE
fix reference to var sqls

### DIFF
--- a/drivers/mysql/query_exec.js
+++ b/drivers/mysql/query_exec.js
@@ -160,7 +160,7 @@ var QueryExec = function(qb, conn) {
                         errors.push(err);
                     }
 
-                    if (sql.length > 0) {
+                    if (sqls.length > 0) {
                         setTimeout(next_batch,0);
                     } else {
                         return callback(errors, results);


### PR DESCRIPTION
In update_batch function an Error is thrown `TypeError: Cannot read property 'length' of undefined`. This PR fixes that by referencing `sqls` as was meant to.
